### PR TITLE
Fix verilator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,16 @@ make sim
 source path/to/vivado/settings64.sh
 make fpga
 ```
+
+## Setup Verilator
+- Install the Verilator simulator following the instructions in the 
+[official page](https://verilator.org/guide/latest/install.html).
+- Set the `VERILATOR_INCLUDE` environment variable in `$HOME/.bashrc`:
+```
+export VERILATOR_INCLUDE=<path>/share/verilator/include
+```
+  - The `<path>` to Verilator can be obtained with the command `which verilator` 
+  after installation. For example if `which verilator` returns 
+  `/usr/local/bin/verilog`, therefore: `<path>`=`/usr/local`. Final command:
+  `export VERILATOR_INCLUDE=/usr/local/share/verilator/include`
+

--- a/software/software.mk
+++ b/software/software.mk
@@ -18,9 +18,9 @@ OBJ+=./build/verilated.o
 
 ./build/verilated.o:
 	mkdir -p ./build;
-	g++ -I. -MMD -I/usr/local/share/verilator/include -I/usr/local/share/verilator/include/vltstd -DVL_PRINTF=printf \
+	g++ -I. -MMD -I$(VERILATOR_INCLUDE) -I$(VERILATOR_INCLUDE)/vltstd -DVL_PRINTF=printf \
 	-DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -Wno-sign-compare -Wno-uninitialized -Wno-unused-but-set-variable \
-	-Wno-unused-parameter -Wno-unused-variable -Wno-shadow -mx32 -g -c /usr/share/verilator/include/verilated.cpp /usr/share/verilator/include/verilated_vcd_c.cpp
+	-Wno-unused-parameter -Wno-unused-variable -Wno-shadow -mx32 -g -c $(VERILATOR_INCLUDE)/verilated.cpp $(VERILATOR_INCLUDE)/verilated_vcd_c.cpp
 	mv *.o ./build/;
 	mv *.d ./build/;
 


### PR DESCRIPTION
- Use `VERILATOR_INCLUDE` variable instead of static paths
- Instructions to setup `VERILATOR_INCLUDE` variable in `README.md`