### PR TITLE
fix(hw): incorrect portmap header name

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -28,8 +28,8 @@ VHDR+=$(wildcard $(VERSAT_HW_DIR)/include/*.vh)
 VHDR+=m_versat_axi_m_port.vh
 VHDR+=m_versat_axi_m_write_port.vh
 VHDR+=m_versat_axi_m_read_port.vh
-VHDR+=m_m_versat_axi_write_portmap.vh
-VHDR+=m_m_versat_axi_read_portmap.vh
+VHDR+=m_versat_axi_write_portmap.vh
+VHDR+=m_versat_axi_read_portmap.vh
 
 #sources
 VSRC+=$(wildcard $(VERSAT_HW_DIR)/src/*.v)
@@ -43,8 +43,8 @@ m_versat_axi_m_write_port.vh:
 m_versat_axi_m_read_port.vh:
 	$(LIB_DIR)/software/python/axi_gen.py axi_m_read_port 'm_versat_' 'm_'
 
-m_m_versat_axi_write_portmap.vh:
+m_versat_axi_write_portmap.vh:
 	$(LIB_DIR)/software/python/axi_gen.py axi_write_portmap 'm_versat_' 'm_' 'm_'
 
-m_m_versat_axi_read_portmap.vh:
+m_versat_axi_read_portmap.vh:
 	$(LIB_DIR)/software/python/axi_gen.py axi_read_portmap 'm_versat_' 'm_' 'm_'


### PR DESCRIPTION
- target generates file named: m_versat_<portmap>.vh instead of m_m_versat_<portmap>.vh
- this was triggering always generation of new .vh file, which in turn triggers new fpga synthesis everytime
