### PR TITLE
feat(hw): update memory default size

### DIFF
--- a/hardware/src/Mem.v
+++ b/hardware/src/Mem.v
@@ -5,7 +5,7 @@
 (* source *) module Mem #(
          parameter MEM_INIT_FILE="none",
          parameter DATA_W = 32,
-         parameter ADDR_W = 5
+         parameter ADDR_W = 7
               )
     (
    //control


### PR DESCRIPTION
- update memory default size to work with McEliece application
- currently Versat does not support parameters during pc emul / verilator stage